### PR TITLE
Fix building with Cabal 1.24

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -28,8 +28,8 @@ main = defaultMainWithHooks simpleUserHooks {
 
 mysqlConfigProgram = (simpleProgram "mysql_config") {
     programFindLocation = \verbosity _ -> do
-      mysql_config  <- findProgramLocation verbosity "mysql_config" 
-      mysql_config5 <- findProgramLocation verbosity "mysql_config5"
+      mysql_config  <- findProgramOnSearchPath verbosity defaultProgramSearchPath "mysql_config"
+      mysql_config5 <- findProgramOnSearchPath verbosity defaultProgramSearchPath "mysql_config5"
       return (mysql_config `mplus` mysql_config5)
   }
 


### PR DESCRIPTION
ATM, it fails with following error at `configure` stage:

    /tmp/cabal-tmp-44775/HDBC-mysql-0.6.6.1/dist/setup/setup.hs:31:7: error:
    • Couldn't match expected type ‘ProgramSearchPath
    -> IO (Maybe (FilePath, [FilePath]))’
    with actual type ‘IO (Maybe FilePath)’
    • In a stmt of a 'do' block:
    mysql_config <- findProgramOnPath "mysql_config" verbosity
    In the expression:
    do { mysql_config <- findProgramOnPath "mysql_config" verbosity;
    mysql_config5 <- findProgramOnPath "mysql_config5" verbosity;
    return (mysql_config `mplus` mysql_config5) }
    In the ‘programFindLocation’ field of a record
    )

The attached commit fixes it by switching to `findProgramOnSearchPath` function.