### PR TITLE
mysql_set_character_set(mysql, "utf8")

### DIFF
--- a/Database/HDBC/MySQL/Connection.hsc
+++ b/Database/HDBC/MySQL/Connection.hsc
@@ -110,6 +110,9 @@ connectMySQL :: MySQLConnectInfo -> IO Connection
 connectMySQL info = do
   mysql_ <- mysql_init nullPtr
   when (mysql_ == nullPtr) (error "mysql_init failed")
+  withCString "utf8" $ \csname_ -> do
+      rv0 <- mysql_set_character_set mysql_ csname_
+      when (rv0 /= 0) (error "mysql_set_character_set failed")
   case mysqlGroup info of
     Just group -> withCString group $ \group_ -> do
                       _ <- mysql_options mysql_ #{const MYSQL_READ_DEFAULT_GROUP} (castPtr group_)
@@ -832,6 +835,13 @@ mysql_init =
 #endif
     mysql_init_
 
+mysql_set_character_set :: Ptr MYSQL -> CString -> IO CInt
+mysql_set_character_set =
+#if DEBUG
+    trace "mysql_set_character_set_"
+#endif
+    mysql_set_character_set_
+
 mysql_options :: Ptr MYSQL -> CInt -> Ptr () -> IO CInt
 mysql_options =
 #if DEBUG
@@ -1000,6 +1010,9 @@ foreign import ccall unsafe "mysql_get_proto_info" mysql_get_proto_info_
 foreign import ccall unsafe "mysql_init" mysql_init_
  :: Ptr MYSQL
  -> IO (Ptr MYSQL)
+
+foreign import ccall unsafe "mysql_set_character_set" mysql_set_character_set_
+ :: Ptr MYSQL -> CString -> IO CInt
 
 foreign import ccall unsafe "mysql_options" mysql_options_
  :: Ptr MYSQL

--- a/Database/HDBC/MySQL/Connection.hsc
+++ b/Database/HDBC/MySQL/Connection.hsc
@@ -110,7 +110,7 @@ connectMySQL :: MySQLConnectInfo -> IO Connection
 connectMySQL info = do
   mysql_ <- mysql_init nullPtr
   when (mysql_ == nullPtr) (error "mysql_init failed")
-  withCString "utf8" $ \csname_ -> do
+  withCString "utf8mb4" $ \csname_ -> do
       rv0 <- mysql_set_character_set mysql_ csname_
       when (rv0 /= 0) (error "mysql_set_character_set failed")
   case mysqlGroup info of

--- a/HDBC-mysql.cabal
+++ b/HDBC-mysql.cabal
@@ -1,7 +1,7 @@
 name:             HDBC-mysql
 category:         Database
 synopsis:         MySQL driver for HDBC
-version:          0.7.0.0
+version:          0.7.0.1
 stability:        Experimental
 maintainer:       Ryan Mulligan <ryan@ryantm.com>
 author:           Chris Waterson


### PR DESCRIPTION
I resolve a following problem.

Garbling occur when insert data like `INSERT INTO foo (col1) VALUES ('あいう')'